### PR TITLE
KeyMapper

### DIFF
--- a/src/main/java/sugaEngine/Game.java
+++ b/src/main/java/sugaEngine/Game.java
@@ -2,7 +2,7 @@ package sugaEngine;
 
 import sugaEngine.graphics.GraphicsPanel;
 import sugaEngine.graphics.DrawListener;
-import sugaEngine.input.GameKeyListener;
+import sugaEngine.input.StackGameKeyListener;
 import sugaEngine.input.GameMouseListener;
 import sugaEngine.input.KeyValues;
 import sugaEngine.physics.PhysicsEngine;
@@ -57,7 +57,7 @@ public abstract class Game {
     /**
      * The key listener that is being used by this game.
      */
-    protected GameKeyListener keyListener;
+    protected StackGameKeyListener keyListener;
 
     /**
      * The mouse listener that is being used by this game.
@@ -76,7 +76,7 @@ public abstract class Game {
      * @param listener The game key listener being used by this game object.
      * @param mouseListener The mouse listener being using by this game object.
      */
-    public Game (GraphicsPanel panel, GameKeyListener listener, GameMouseListener mouseListener) {
+    public Game (GraphicsPanel panel, StackGameKeyListener listener, GameMouseListener mouseListener) {
         this.panel = panel;
         keyListener = listener;
         this.mouseListener = mouseListener;

--- a/src/main/java/sugaEngine/Game.java
+++ b/src/main/java/sugaEngine/Game.java
@@ -2,7 +2,7 @@ package sugaEngine;
 
 import sugaEngine.graphics.GraphicsPanel;
 import sugaEngine.graphics.DrawListener;
-import sugaEngine.input.StackGameKeyListener;
+import sugaEngine.input.GameKeyListenerInterface;
 import sugaEngine.input.GameMouseListener;
 import sugaEngine.input.KeyValues;
 import sugaEngine.physics.PhysicsEngine;
@@ -17,12 +17,6 @@ import java.util.*;
  * @author Sugaku
  */
 public abstract class Game {
-
-    /**
-     * These are keys that are currently being held. That can be useful information in it of itself but this is used to
-     * ignore future key pressed messages.
-     */
-    protected List<Integer> pressedKeys = new ArrayList<>();
 
     /**
      * A list of game objects for this game. Their logic should be called every cycle.
@@ -57,7 +51,7 @@ public abstract class Game {
     /**
      * The key listener that is being used by this game.
      */
-    protected StackGameKeyListener keyListener;
+    protected GameKeyListenerInterface keyListener;
 
     /**
      * The mouse listener that is being used by this game.
@@ -76,7 +70,7 @@ public abstract class Game {
      * @param listener The game key listener being used by this game object.
      * @param mouseListener The mouse listener being using by this game object.
      */
-    public Game (GraphicsPanel panel, StackGameKeyListener listener, GameMouseListener mouseListener) {
+    public Game (GraphicsPanel panel, GameKeyListenerInterface listener, GameMouseListener mouseListener) {
         this.panel = panel;
         keyListener = listener;
         this.mouseListener = mouseListener;
@@ -119,19 +113,12 @@ public abstract class Game {
             MouseEvent e = mice.pop();
             loadedScene.mouseInput(e.getPoint(), e.getButton() == 1);
         }
-        Stack<Integer> keys = keyListener.getKeysPressed();
-        while (keys.size() > 0) {
-            int key = keys.pop();
-            if (pressedKeys.contains(key)) continue;
-            pressedKeys.add(key);
-            loadedScene.keyboardInput(KeyValues.toEnum(key), true);
-        }
-        keys = keyListener.getKeysDepressed();
-        while (keys.size() > 0) {
-            int key = keys.pop();
-            pressedKeys.remove((Integer) key);
-            loadedScene.keyboardInput(KeyValues.toEnum(key), false);
-        }
+        Stack<KeyValues> keys = keyListener.getKeyPresses();
+        while (keys.size() > 0)
+            loadedScene.keyboardInput(keys.pop(), true);
+        keys = keyListener.getKeyReleases();
+        while (keys.size() > 0)
+            loadedScene.keyboardInput(keys.pop(), false);
     }
 
     /**

--- a/src/main/java/sugaEngine/input/BasicKeyMapper.java
+++ b/src/main/java/sugaEngine/input/BasicKeyMapper.java
@@ -6,7 +6,7 @@ package sugaEngine.input;
  *
  * @author Sugaku
  */
-public class DefaultKeyMapper implements KeyMapper {
+public class BasicKeyMapper implements KeyMapper {
 
     /**
      * The array used to convert between keycodes and keys.
@@ -14,9 +14,9 @@ public class DefaultKeyMapper implements KeyMapper {
     protected KeyValues[] values = new KeyValues[256];
 
     /**
-     * Constructs the DefaultKeyMapper. Initializes everything to null before iterating through the values of KeyValues.
+     * Constructs the BasicKeyMapper. Initializes everything to null before iterating through the values of KeyValues.
      */
-    public DefaultKeyMapper () {
+    public BasicKeyMapper () {
         for (int i = 0; i < 255; i++)
             values[i] = null;
         for (KeyValues v : KeyValues.values())

--- a/src/main/java/sugaEngine/input/DefaultKeyMapper.java
+++ b/src/main/java/sugaEngine/input/DefaultKeyMapper.java
@@ -1,0 +1,48 @@
+package sugaEngine.input;
+
+/**
+ * The default KeyMapper works by creating an array the size of the maximally supported keycode value and storing the
+ * resulting enum values at each keycode index.
+ *
+ * @author Sugaku
+ */
+public class DefaultKeyMapper implements KeyMapper {
+
+    /**
+     * The array used to convert between keycodes and keys.
+     */
+    protected KeyValues[] values = new KeyValues[256];
+
+    /**
+     * Constructs the DefaultKeyMapper. Initializes everything to null before iterating through the values of KeyValues.
+     */
+    public DefaultKeyMapper () {
+        for (int i = 0; i < 255; i++)
+            values[i] = null;
+        for (KeyValues v : KeyValues.values())
+            values[v.getValue()] = v;
+    }
+
+    /**
+     * Converts the given keycode into a KeyValue.
+     *
+     * @param keycode The keycode to convert into a value.
+     * @return The enum value of the given key.
+     */
+    @Override
+    public KeyValues convert (int keycode) {
+        return values[keycode];
+    }
+
+    /**
+     * Sets the given keycode to the given enum value. Will replace the current result from that keycode.
+     *
+     * @param keycode The keycode to change the mapping of.
+     * @param key     The new key to map that keycode to.
+     */
+    @Override
+    public void set (int keycode, KeyValues key) {
+        if (keycode < 0 || keycode > 255) throw new IllegalArgumentException("Keycode not supported [0,255]: " + keycode);
+        values[keycode] = key;
+    }
+}

--- a/src/main/java/sugaEngine/input/GameKeyListener.java
+++ b/src/main/java/sugaEngine/input/GameKeyListener.java
@@ -1,87 +1,23 @@
 package sugaEngine.input;
 
 import javax.swing.*;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.util.Stack;
 
 /**
- * The game key listener is a listener for key presses to be used inside an implemented game.
+ * Reference to the StackGameKeyListener which is the GameKeyListener for version 1.1.1-BETA. This name will be taken by
+ * an interface in v2.1.1.
  *
  * @author Sugaku
  */
-public class GameKeyListener implements KeyListener {
+@Deprecated
+public class GameKeyListener extends StackGameKeyListener {
 
     /**
-     * A stack of keys that have been pressed and need to be handled by the game.
-     */
-    protected Stack<Integer> keysPressed = new Stack<>();
-
-    /**
-     * A stack of keys that have been depressed and need to be handled by the game.
-     */
-    protected Stack<Integer> keysDepressed = new Stack<>();
-
-    /**
-     * Creates a new GameKeyListener for use in a game.
+     * Creates a new StackGameKeyListener for use in a game.
      *
      * @param frame The JFrame that this KeyListener is using.
      */
+    @Deprecated
     public GameKeyListener (JFrame frame) {
-        frame.addKeyListener(this);
-    }
-
-    /**
-     * Invoked when a key has been typed.
-     * See the class description for {@link KeyEvent} for a definition of
-     * a key typed event.
-     *
-     * @param e the event to be processed
-     */
-    @Override
-    public void keyTyped (KeyEvent e) {
-
-    }
-
-    /**
-     * Invoked when a key has been pressed.
-     * See the class description for {@link KeyEvent} for a definition of
-     * a key pressed event.
-     *
-     * @param e the event to be processed
-     */
-    @Override
-    public void keyPressed (KeyEvent e) {
-        keysPressed.add(e.getKeyCode());
-    }
-
-    /**
-     * Invoked when a key has been released.
-     * See the class description for {@link KeyEvent} for a definition of
-     * a key released event.
-     *
-     * @param e the event to be processed
-     */
-    @Override
-    public void keyReleased (KeyEvent e) {
-        keysDepressed.add(e.getKeyCode());
-    }
-
-    /**
-     * Accessor method for the stack of keys that has been pressed. Should be used by games to read key presses.
-     *
-     * @return The stack of keys that have been pressed.
-     */
-    public Stack<Integer> getKeysPressed() {
-        return keysPressed;
-    }
-
-    /**
-     * Accessor method for the stack of keys that have been depressed. Should be used by games to read key presses.
-     *
-     * @return The stack of keys that have been depressed.
-     */
-    public Stack<Integer> getKeysDepressed () {
-        return keysDepressed;
+        super(frame);
     }
 }

--- a/src/main/java/sugaEngine/input/GameKeyListenerInterface.java
+++ b/src/main/java/sugaEngine/input/GameKeyListenerInterface.java
@@ -1,12 +1,47 @@
 package sugaEngine.input;
 
-import javax.swing.*;
 import java.awt.event.KeyListener;
+import java.util.Stack;
 
 /**
  * The GameKeyListenerInterface is an object that responds whenever a key is pressed
  */
-// todo rename to 'GameKeyListener'
+// todo v2.*.* rename to 'GameKeyListener'
 public interface GameKeyListenerInterface extends KeyListener {
 
+    /**
+     * Overrides the currently used KeyMapper with a new KeyMapper.
+     *
+     * @param mapping The new mapping to apply to this key listener.
+     */
+    void setKeyMapping (KeyMapper mapping);
+
+    /**
+     * Accessor method for the currently used KeyMapper. Helpful for modifying mappings.
+     *
+     * @return The KeyMapper instance being used by this KeyMapper.
+     */
+    KeyMapper getKeyMapping ();
+
+    /**
+     * Checks whether the given key is currently being held or not.
+     *
+     * @param key The key to check if it's being held or not.
+     * @return True if the key is currently being held, otherwise false.
+     */
+    boolean isHeld (KeyValues key);
+
+    /**
+     * Returns a stack of key presses that have not yet been handled.
+     *
+     * @return The 'to handle' stack of key presses.
+     */
+    Stack<KeyValues> getKeyPresses ();
+
+    /**
+     * Returns a stack of key releases that have not yet been handled.
+     *
+     * @return The 'to handle' stack of key releases.
+     */
+    Stack<KeyValues> getKeyReleases ();
 }

--- a/src/main/java/sugaEngine/input/GameKeyListenerInterface.java
+++ b/src/main/java/sugaEngine/input/GameKeyListenerInterface.java
@@ -1,0 +1,12 @@
+package sugaEngine.input;
+
+import javax.swing.*;
+import java.awt.event.KeyListener;
+
+/**
+ * The GameKeyListenerInterface is an object that responds whenever a key is pressed
+ */
+// todo rename to 'GameKeyListener'
+public interface GameKeyListenerInterface extends KeyListener {
+
+}

--- a/src/main/java/sugaEngine/input/KeyMapper.java
+++ b/src/main/java/sugaEngine/input/KeyMapper.java
@@ -1,0 +1,25 @@
+package sugaEngine.input;
+
+/**
+ * The key mapper is used to map keys between their keycodes and the KeyValues enum.
+ *
+ * @author Sugaku
+ */
+public interface KeyMapper {
+
+    /**
+     * Converts the given keycode into a KeyValue.
+     *
+     * @param keycode The keycode to convert into a value.
+     * @return The enum value of the given key.
+     */
+    KeyValues convert (int keycode);
+
+    /**
+     * Sets the given keycode to the given enum value. Will replace the current result from that keycode.
+     *
+     * @param keycode The keycode to change the mapping of.
+     * @param key     The new key to map that keycode to.
+     */
+    void set (int keycode, KeyValues key);
+}

--- a/src/main/java/sugaEngine/input/KeyValues.java
+++ b/src/main/java/sugaEngine/input/KeyValues.java
@@ -5,7 +5,7 @@ package sugaEngine.input;
  *
  * @author Sugaku
  */
-public enum KeyValues {
+public enum KeyValues { // todo rename to KeyValue, requires Major version increment.
 
     /**
      * The enter key maps to keycode '10'.

--- a/src/main/java/sugaEngine/input/KeyValues.java
+++ b/src/main/java/sugaEngine/input/KeyValues.java
@@ -91,11 +91,12 @@ public enum KeyValues { // todo rename to KeyValue, requires Major version incre
     }
 
     /**
-     * Converts the given int keycode into an enum value from KeyValues.
+     * Converts the given int keycode into an enum value from KeyValues. {@link KeyMapper}
      *
      * @param code The code of the key pressed.
      * @return The enum value of the key if present, otherwise null.
      */
+    @Deprecated
     public static KeyValues toEnum (int code) { // Might be a bit slow for input handling. Perhaps prioritize more popular keys.
         for (KeyValues k : KeyValues.values())  //  This would also be a good level for key remapping.
             if (k.getValue() == code)

--- a/src/main/java/sugaEngine/input/StackGameKeyListener.java
+++ b/src/main/java/sugaEngine/input/StackGameKeyListener.java
@@ -1,0 +1,88 @@
+package sugaEngine.input;
+
+import javax.swing.*;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.util.Stack;
+
+/**
+ * The StackGameKeyListener creates a stack of pressed, and depressed events which are then accessed with accessor
+ * methods to be read by the game.
+ *
+ * @author Sugaku
+ */
+public class StackGameKeyListener implements KeyListener {
+
+    /**
+     * A stack of keys that have been pressed and need to be handled by the game.
+     */
+    protected Stack<Integer> keysPressed = new Stack<>();
+
+    /**
+     * A stack of keys that have been depressed and need to be handled by the game.
+     */
+    protected Stack<Integer> keysDepressed = new Stack<>();
+
+    /**
+     * Creates a new StackGameKeyListener for use in a game.
+     *
+     * @param frame The JFrame that this KeyListener is using.
+     */
+    public StackGameKeyListener (JFrame frame) {
+        frame.addKeyListener(this);
+    }
+
+    /**
+     * Invoked when a key has been typed.
+     * See the class description for {@link KeyEvent} for a definition of
+     * a key typed event.
+     *
+     * @param e the event to be processed
+     */
+    @Override
+    public void keyTyped (KeyEvent e) {
+
+    }
+
+    /**
+     * Invoked when a key has been pressed.
+     * See the class description for {@link KeyEvent} for a definition of
+     * a key pressed event.
+     *
+     * @param e the event to be processed
+     */
+    @Override
+    public void keyPressed (KeyEvent e) {
+        keysPressed.add(e.getKeyCode());
+    }
+
+    /**
+     * Invoked when a key has been released.
+     * See the class description for {@link KeyEvent} for a definition of
+     * a key released event.
+     *
+     * @param e the event to be processed
+     */
+    @Override
+    public void keyReleased (KeyEvent e) {
+        keysDepressed.add(e.getKeyCode());
+    }
+
+    /**
+     * Accessor method for the stack of keys that has been pressed. Should be used by games to read key presses.
+     *
+     * @return The stack of keys that have been pressed.
+     */
+    public Stack<Integer> getKeysPressed () {
+        return keysPressed;
+    }
+
+    /**
+     * Accessor method for the stack of keys that have been depressed. Should be used by games to read key presses.
+     *
+     * @return The stack of keys that have been depressed.
+     */
+    public Stack<Integer> getKeysDepressed () {
+        return keysDepressed;
+    }
+}

--- a/src/main/java/sugaEngine/input/StackGameKeyListener.java
+++ b/src/main/java/sugaEngine/input/StackGameKeyListener.java
@@ -76,6 +76,7 @@ public class StackGameKeyListener implements GameKeyListenerInterface {
     @Override
     public void keyPressed (KeyEvent e) {
         KeyValues key = mapper.convert(e.getKeyCode());
+        if (heldKeys.contains(key)) return;
         keysPressed.add(key);
         heldKeys.add(key);
     }
@@ -90,6 +91,7 @@ public class StackGameKeyListener implements GameKeyListenerInterface {
     @Override
     public void keyReleased (KeyEvent e) {
         KeyValues key = mapper.convert(e.getKeyCode());
+        if (!heldKeys.contains(key)) return;
         keysReleased.add(key);
         heldKeys.remove(key);
     }

--- a/src/main/java/sugaEngine/input/StackGameKeyListener.java
+++ b/src/main/java/sugaEngine/input/StackGameKeyListener.java
@@ -2,7 +2,8 @@ package sugaEngine.input;
 
 import javax.swing.*;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Stack;
 
 /**
@@ -11,25 +12,46 @@ import java.util.Stack;
  *
  * @author Sugaku
  */
-public class StackGameKeyListener implements KeyListener {
+public class StackGameKeyListener implements GameKeyListenerInterface {
+
+    /**
+     * The KeyMapper being used by this listener.
+     */
+    protected KeyMapper mapper;
+
+    /**
+     * A collection of keys that are currently being held.
+     */
+    protected Collection<KeyValues> heldKeys = new ArrayList<>();
 
     /**
      * A stack of keys that have been pressed and need to be handled by the game.
      */
-    protected Stack<Integer> keysPressed = new Stack<>();
+    protected Stack<KeyValues> keysPressed = new Stack<>();
 
     /**
      * A stack of keys that have been depressed and need to be handled by the game.
      */
-    protected Stack<Integer> keysDepressed = new Stack<>();
+    protected Stack<KeyValues> keysReleased = new Stack<>();
 
     /**
-     * Creates a new StackGameKeyListener for use in a game.
+     * Creates a new StackGameKeyListener for use in a game. Uses the BasicKeyMapper by default.
      *
      * @param frame The JFrame that this KeyListener is using.
      */
     public StackGameKeyListener (JFrame frame) {
+        this(frame, new BasicKeyMapper());
+    }
+
+    /**
+     * Creates a new StackGameKeyListener for use in a game.
+     *
+     * @param frame  The JFrame that this KeyListener is using.
+     * @param mapper The KeyMapper to be used by this KeyListener.
+     */
+    public StackGameKeyListener (JFrame frame, KeyMapper mapper) {
         frame.addKeyListener(this);
+        this.mapper = mapper;
     }
 
     /**
@@ -53,7 +75,9 @@ public class StackGameKeyListener implements KeyListener {
      */
     @Override
     public void keyPressed (KeyEvent e) {
-        keysPressed.add(e.getKeyCode());
+        KeyValues key = mapper.convert(e.getKeyCode());
+        keysPressed.add(key);
+        heldKeys.add(key);
     }
 
     /**
@@ -65,7 +89,9 @@ public class StackGameKeyListener implements KeyListener {
      */
     @Override
     public void keyReleased (KeyEvent e) {
-        keysDepressed.add(e.getKeyCode());
+        KeyValues key = mapper.convert(e.getKeyCode());
+        keysReleased.add(key);
+        heldKeys.remove(key);
     }
 
     /**
@@ -73,8 +99,11 @@ public class StackGameKeyListener implements KeyListener {
      *
      * @return The stack of keys that have been pressed.
      */
+    @Deprecated // Remove v2.*.*
     public Stack<Integer> getKeysPressed () {
-        return keysPressed;
+        Stack<Integer> s = new Stack<>();
+        for (KeyValues k : keysPressed) s.add(k.getValue());
+        return s;
     }
 
     /**
@@ -82,7 +111,61 @@ public class StackGameKeyListener implements KeyListener {
      *
      * @return The stack of keys that have been depressed.
      */
+    @Deprecated // Remove v2.*.*
     public Stack<Integer> getKeysDepressed () {
-        return keysDepressed;
+        Stack<Integer> s = new Stack<>();
+        for (KeyValues k : keysReleased) s.add(k.getValue());
+        return s;
+    }
+
+    /**
+     * Overrides the currently used KeyMapper with a new KeyMapper.
+     *
+     * @param mapping The new mapping to apply to this key listener.
+     */
+    @Override
+    public void setKeyMapping (KeyMapper mapping) {
+        mapper = mapping;
+    }
+
+    /**
+     * Accessor method for the currently used KeyMapper. Helpful for modifying mappings.
+     *
+     * @return The KeyMapper instance being used by this KeyMapper.
+     */
+    @Override
+    public KeyMapper getKeyMapping () {
+        return mapper;
+    }
+
+    /**
+     * Checks whether the given key is currently being held or not.
+     *
+     * @param key The key to check if it's being held or not.
+     * @return True if the key is currently being held, otherwise false.
+     */
+    @Override
+    public boolean isHeld (KeyValues key) {
+        return heldKeys.contains(key);
+    }
+
+    /**
+     * Returns a stack of key presses that have not yet been handled.
+     *
+     * @return The 'to handle' stack of key presses.
+     */
+    @Override
+    public Stack<KeyValues> getKeyPresses () {
+        return keysPressed;
+    }
+
+    /**
+     * Returns a stack of key releases that have not yet been handled.
+     *
+     * @return The 'to handle' stack of key releases.
+     */
+    @Override
+    public Stack<KeyValues> getKeyReleases () {
+        return keysReleased;
     }
 }


### PR DESCRIPTION
- Added the KeyMapper interface.
- Implemented the DefaultKeyMapper class.
- Renamed GameKeyListener to StackGameKeyListener. Created a deprecated version named GameKeyListener for now.
- Renamed DefaultKeyMapper to BasicKeyMapper.
- Created an Interface for GameKeyListeners. Poorly named until major version increment.
- Reimplemented most of the functionality to update the StackGameKeyListener. Deprecated the get Stack<Integer> calls.
- Outlined the GameKeyListenerInterface.
- Refactored methods to use Interface names instead of specific implementations.
- Removed usages of deprecated methods.
- Deprecated KeyValues.toEnum(), see KeyMapper.